### PR TITLE
Handle multiple microchip OIDs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ make check
 The code by default uses the Open Lighting PLASA ID (0x7a70). This range is
 owned by the Open Lighting Project and at this time we do not sub-license
 ranges to anyone else. You *may not* ship product with the Open Lighting
-PLASA id.
+PLASA ID.
 
 Per https://wiki.openlighting.org/index.php/Open_Lighting_Allocations the
 UIDs 7a70:fffffe00 to 7a70:fffffefe may be used for development (in house)

--- a/README.md
+++ b/README.md
@@ -65,6 +65,17 @@ make
 make check
 ```
 
+## PLASA Identifiers & UIDs
+
+The code by default uses the Open Lighting PLASA ID (0x7a70). This range is
+owned by the Open Lighting Project and at this time we do not sub-license
+ranges to anyone else. You *may not* ship product with the Open Lighting
+PLASA id.
+
+Per https://wiki.openlighting.org/index.php/Open_Lighting_Allocations the
+UIDs 7a70:fffffe00 to 7a70:fffffefe may be used for development (in house)
+purposes.
+
 ## Dev Notes
 
 A bulk-in transfer with a full 512 bytes of DMX data takes < 1ms on my mac

--- a/boardcfg/ethernet_sk2/bootloader_settings.h
+++ b/boardcfg/ethernet_sk2/bootloader_settings.h
@@ -22,7 +22,6 @@
 
 #include "bootloader.h"
 #include "common_settings.h"
-#include "config_options.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -73,12 +72,6 @@ extern "C" {
  * @brief True if the switch is active high, false if active low.
  */
 #define SWITCH_ACTIVE_HIGH false
-
-/**
- * @brief The hardware model.
- * @sa JaRuleModel
- */
-#define HARDWARE_MODEL MODEL_ETHERNET_SK2
 
 /**
  * @brief The LEDS to flash in bootloader mode.

--- a/boardcfg/ethernet_sk2/common_settings.h
+++ b/boardcfg/ethernet_sk2/common_settings.h
@@ -67,6 +67,12 @@ extern "C" {
 #define CFG_UID_SOURCE CFG_OPT_UID_FROM_MAC
 
 /**
+ * @brief The hardware model.
+ * @sa JaRuleModel
+ */
+#define HARDWARE_MODEL MODEL_ETHERNET_SK2
+
+/**
  * @}
  *
  * @name Developer Settings

--- a/boardcfg/number1/bootloader_settings.h
+++ b/boardcfg/number1/bootloader_settings.h
@@ -22,7 +22,6 @@
 
 #include "bootloader.h"
 #include "common_settings.h"
-#include "config_options.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -73,12 +72,6 @@ extern "C" {
  * @brief True if the switch is active high, false if active low.
  */
 #define SWITCH_ACTIVE_HIGH false
-
-/**
- * @brief The hardware model.
- * @sa JaRuleModel
- */
-#define HARDWARE_MODEL MODEL_NUMBER1
 
 /**
  * @brief The LEDS to flash in bootloader mode.

--- a/boardcfg/number1/common_settings.h
+++ b/boardcfg/number1/common_settings.h
@@ -67,6 +67,12 @@ extern "C" {
 #define CFG_UID_SOURCE CFG_OPT_UID_FROM_MAC
 
 /**
+ * @brief The hardware model.
+ * @sa JaRuleModel
+ */
+#define HARDWARE_MODEL MODEL_NUMBER1
+
+/**
  * @}
  *
  * @name Developer Settings

--- a/boardcfg/number8/bootloader_settings.h
+++ b/boardcfg/number8/bootloader_settings.h
@@ -22,7 +22,6 @@
 
 #include "bootloader.h"
 #include "common_settings.h"
-#include "config_options.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -73,12 +72,6 @@ extern "C" {
  * @brief True if the switch is active high, false if active low.
  */
 #define SWITCH_ACTIVE_HIGH false
-
-/**
- * @brief The hardware model.
- * @sa JaRuleModel
- */
-#define HARDWARE_MODEL MODEL_NUMBER8
 
 /**
  * @brief The LEDS to flash in bootloader mode.

--- a/boardcfg/number8/common_settings.h
+++ b/boardcfg/number8/common_settings.h
@@ -67,6 +67,12 @@ extern "C" {
 #define CFG_UID_SOURCE CFG_OPT_UID_FROM_MAC
 
 /**
+ * @brief The hardware model.
+ * @sa JaRuleModel
+ */
+#define HARDWARE_MODEL MODEL_NUMBER8
+
+/**
  * @}
  *
  * @name Developer Settings

--- a/boardcfg/template/bootloader_settings.h
+++ b/boardcfg/template/bootloader_settings.h
@@ -75,12 +75,6 @@ extern "C" {
 #define SWITCH_ACTIVE_HIGH false
 
 /**
- * @brief The hardware model.
- * @sa JaRuleModel
- */
-#define HARDWARE_MODEL MODEL_UNDEFINED
-
-/**
  * @brief The LEDS to flash in bootloader mode.
  */
 const Bootloader_LEDs BOOTLOADER_LEDS;

--- a/boardcfg/template/common_settings.h
+++ b/boardcfg/template/common_settings.h
@@ -67,6 +67,12 @@ extern "C" {
 #define CFG_UID_SOURCE CFG_OPT_UID_FROM_MAC
 
 /**
+ * @brief The hardware model.
+ * @sa JaRuleModel
+ */
+#define HARDWARE_MODEL MODEL_UNDEFINED
+
+/**
  * @}
  *
  * @name Developer Settings

--- a/common/uid_store.c
+++ b/common/uid_store.c
@@ -45,15 +45,15 @@ inline uint8_t ShiftLeft(uint8_t b) {
 void UIDStore_Init() {
   // The UID is derived from the RDM manufacturer ID & the MAC address.
   // The first 3 bytes of the MAC address is the Microchip OIDs, which are one
-  // of 00:1e:c0, 00:04:A3 or D8:80:39. The bottom 3 bytes contain the unique
+  // of 00:1E:C0, 00:04:A3 or D8:80:39. The bottom 3 bytes contain the unique
   // serial number.
   //
   // To support more than one responder per device, we set the lower 4 bits of
   // the UID to 0 so we have 16 responders per device. These means the complete
   // UID takes the form:
   //   MMMM:XAAAAAA0
-  // Where M is the PLASA manufacturer ID and A are the values from the MAC
-  // address. X is derived from the OID:
+  // Where M is the PLASA manufacturer ID, X is derived from the OID and A is
+  // the values from the MAC address. X is derived from the OID as follows:
   //
   //   00:1E:C0 -> 1
   //   D8:80:39 -> 2

--- a/common/uid_store.c
+++ b/common/uid_store.c
@@ -31,6 +31,8 @@
 #include "peripheral/eth/plib_eth.h"
 
 static uint8_t kUIDArray[UID_LENGTH];
+static const uint32_t MICROCHIP_OID1 = 0x00001ec0;
+static const uint32_t MICROCHIP_OID2 = 0x00d88039;
 
 inline uint8_t ShiftRight(uint8_t b) {
   return (b >> 4) & 0x0f;
@@ -42,23 +44,49 @@ inline uint8_t ShiftLeft(uint8_t b) {
 
 void UIDStore_Init() {
   // The UID is derived from the RDM manufacturer ID & the MAC address.
-  // The first 3 bytes of the MAC address is the Microchip OID 00:1e:c0 which
-  // is constant. The bottom 3 bytes contain the unique serial number.
+  // The first 3 bytes of the MAC address is the Microchip OIDs, which are one
+  // of 00:1e:c0, 00:04:A3 or D8:80:39. The bottom 3 bytes contain the unique
+  // serial number.
   //
   // To support more than one responder per device, we set the lower 4 bits of
   // the UID to 0 so we have 16 responders per device. These means the complete
   // UID takes the form:
-  //   MMMM:1AAAAAA0
+  //   MMMM:XAAAAAA0
   // Where M is the PLASA manufacturer ID and A are the values from the MAC
-  // address.
-  kUIDArray[0] = CFG_MANUFACTURER_ID >> 8;
-  kUIDArray[1] = CFG_MANUFACTURER_ID & 0xff;
-  kUIDArray[2] = 0x10 + ShiftRight(PLIB_ETH_StationAddressGet(ETH_ID_0, 4));
-  kUIDArray[3] = ShiftLeft(PLIB_ETH_StationAddressGet(ETH_ID_0, 4)) +
-                 ShiftRight(PLIB_ETH_StationAddressGet(ETH_ID_0, 5));
-  kUIDArray[4] = ShiftLeft(PLIB_ETH_StationAddressGet(ETH_ID_0, 5)) +
-                 ShiftRight(PLIB_ETH_StationAddressGet(ETH_ID_0, 6));
-  kUIDArray[5] = ShiftLeft(PLIB_ETH_StationAddressGet(ETH_ID_0, 6));
+  // address. X is derived from the OID:
+  //
+  //   00:1E:C0 -> 1
+  //   D8:80:39 -> 2
+  uint32_t oid = (PLIB_ETH_StationAddressGet(ETH_ID_0, 1) << 16) +
+                 (PLIB_ETH_StationAddressGet(ETH_ID_0, 2) << 8) +
+                 PLIB_ETH_StationAddressGet(ETH_ID_0, 3);
+  uint8_t upper_id = 0;
+  if (oid == MICROCHIP_OID1) {
+    upper_id = 0x10;
+  } else if (oid == MICROCHIP_OID2) {
+    upper_id = 0x20;
+  }
+
+  if (upper_id) {
+    kUIDArray[0] = CFG_MANUFACTURER_ID >> 8;
+    kUIDArray[1] = CFG_MANUFACTURER_ID & 0xff;
+    kUIDArray[2] = upper_id +
+                   ShiftRight(PLIB_ETH_StationAddressGet(ETH_ID_0, 4));
+    kUIDArray[3] = ShiftLeft(PLIB_ETH_StationAddressGet(ETH_ID_0, 4)) +
+                   ShiftRight(PLIB_ETH_StationAddressGet(ETH_ID_0, 5));
+    kUIDArray[4] = ShiftLeft(PLIB_ETH_StationAddressGet(ETH_ID_0, 5)) +
+                   ShiftRight(PLIB_ETH_StationAddressGet(ETH_ID_0, 6));
+    kUIDArray[5] = ShiftLeft(PLIB_ETH_StationAddressGet(ETH_ID_0, 6));
+  } else {
+    // If we didn't match the OID, default to the NULL UID to make it obvious
+    // what happened
+    kUIDArray[0] = 0;
+    kUIDArray[1] = 0;
+    kUIDArray[2] = 0;
+    kUIDArray[3] = 0;
+    kUIDArray[4] = 0;
+    kUIDArray[5] = 0;
+  }
 }
 
 const uint8_t* const kUID = &kUIDArray[0];

--- a/doxygen/message-format.md
+++ b/doxygen/message-format.md
@@ -15,7 +15,8 @@ the Device to the Host are *Responses*.
 
 # Byte Ordering {#message-endian}
 
-All multi-byte fields are sent little endian (LSB first)
+All multi-byte fields are sent little endian (LSB first) unless otherwise
+specified.
 
 # Message Format {#message-format}
 
@@ -146,27 +147,34 @@ The response contains no data.
 
 @returns @ref RC_OK.
 
-## Get UID  {#message-commands-getuid}
+## Get Hardware Information  {#message-commands-gethardware}
 
-Get the UID of the device.
+Get the hardware infomation for the device.
 
-### Request Payload {#message-commands-getuid-req}
+### Request Payload {#message-commands-gethardware-req}
 
 The request contains no data.
 
-### Response Payload {#message-commands-getuid-res}
+### Response Payload {#message-commands-gethardware-res}
 
 <pre>
   0                   1                   2                   3
   0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
- |                                UID                            |
+ |          Model ID               |             UID             |
  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
- |           UID (cont.)           |
+ |                             UID (cont.)                       |
+ +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ |                            MAC Address                        |
+ +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ |       MAC Address (cont.)       |
  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 </pre>
 
+@param Model_Id The \ref JaRuleModel of the device.
 @param UID The UID of the device, in network byte order.
+@param MAC The MAC address of the device, in network byte order. If the device
+does not have a MAC this will be 0.
 
 @returns @ref RC_OK.
 

--- a/firmware/src/constants.h
+++ b/firmware/src/constants.h
@@ -55,6 +55,15 @@
 #define USB_POLLING_INTERVAL 1u
 
 // *****************************************************************************
+// Network specific constants
+// *****************************************************************************
+
+/**
+ * @brief The size of a MAC address
+ */
+enum { MAC_ADDRESS_SIZE = 6 };
+
+// *****************************************************************************
 // RDM specific constants
 // *****************************************************************************
 
@@ -90,10 +99,10 @@ typedef enum {
   COMMAND_SET_MODE = 0x01,
 
   /**
-   * @brief Get the UID of the device.
-   * @sa @ref message-commands-getuid.
+   * @brief Get the hardware info for the device.
+   * @sa @ref message-commands-gethardware.
    */
-  COMMAND_GET_UID = 0x02,
+  COMMAND_GET_HARDWARE_INFO = 0x02,
 
   // User Configuration
   /**

--- a/firmware/src/rdm.h
+++ b/firmware/src/rdm.h
@@ -220,11 +220,6 @@ static const uint32_t IPV4_UNCONFIGURED = 0u;
 static const uint8_t MAX_NETMASK = 32u;
 
 /**
- * @brief The size of a MAC address
- */
-enum { MAC_ADDRESS_SIZE = 6 };
-
-/**
  * @brief DHCP Status
  */
 typedef enum {

--- a/tests/harmony/Makefile.mk
+++ b/tests/harmony/Makefile.mk
@@ -1,6 +1,8 @@
 noinst_LTLIBRARIES += tests/harmony/mocks/libharmonymock.la
 
 tests_harmony_mocks_libharmonymock_la_SOURCES = \
+    tests/harmony/mocks/plib_eth_mock.cpp \
+    tests/harmony/mocks/plib_eth_mock.h \
     tests/harmony/mocks/plib_ic_mock.cpp \
     tests/harmony/mocks/plib_ic_mock.h \
     tests/harmony/mocks/plib_nvm_mock.cpp \

--- a/tests/harmony/include/peripheral/eth/plib_eth.h
+++ b/tests/harmony/include/peripheral/eth/plib_eth.h
@@ -1,0 +1,24 @@
+/*
+ * This is the stub for plib_eth.h used for the tests. It contains the bare
+ * minimum required to implement the mock ethernet symbols.
+ */
+
+#ifndef TESTS_HARMONY_INCLUDE_PERIPHERAL_ETH_PLIB_ETH_H_
+#define TESTS_HARMONY_INCLUDE_PERIPHERAL_ETH_PLIB_ETH_H_
+
+#ifdef  __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+  ETH_ID_0 = 0,
+  ETH_NUMBER_OF_MODULES
+} ETH_MODULE_ID;
+
+uint8_t PLIB_ETH_StationAddressGet(ETH_MODULE_ID index, uint8_t which);
+
+#ifdef  __cplusplus
+}
+#endif
+
+#endif  // TESTS_HARMONY_INCLUDE_PERIPHERAL_ETH_PLIB_ETH_H_

--- a/tests/harmony/mocks/plib_eth_mock.cpp
+++ b/tests/harmony/mocks/plib_eth_mock.cpp
@@ -1,0 +1,17 @@
+#include <gmock/gmock.h>
+#include "plib_eth_mock.h"
+
+namespace {
+  MockPeripheralEth *g_plib_eth_mock = NULL;
+}
+
+void PLIB_Eth_SetMock(MockPeripheralEth* mock) {
+  g_plib_eth_mock = mock;
+}
+
+uint8_t PLIB_ETH_StationAddressGet(ETH_MODULE_ID index, uint8_t which) {
+  if (g_plib_eth_mock) {
+    return g_plib_eth_mock->StationAddressGet(index, which);
+  }
+  return 0;
+}

--- a/tests/harmony/mocks/plib_eth_mock.h
+++ b/tests/harmony/mocks/plib_eth_mock.h
@@ -1,0 +1,14 @@
+#ifndef TESTS_HARMONY_MOCKS_PLIB_ETH_MOCK_H_
+#define TESTS_HARMONY_MOCKS_PLIB_ETH_MOCK_H_
+
+#include <gmock/gmock.h>
+#include "peripheral/eth/plib_eth.h"
+
+class MockPeripheralEth {
+ public:
+  MOCK_METHOD2(StationAddressGet, uint8_t(ETH_MODULE_ID index, uint8_t which));
+};
+
+void PLIB_Eth_SetMock(MockPeripheralEth* mock);
+
+#endif  // TESTS_HARMONY_MOCKS_PLIB_ETH_MOCK_H_

--- a/tests/system_config/app_settings.h
+++ b/tests/system_config/app_settings.h
@@ -20,6 +20,8 @@
 #ifndef TESTS_SYSTEM_CONFIG_APP_SETTINGS_H_
 #define TESTS_SYSTEM_CONFIG_APP_SETTINGS_H_
 
+#include "common_settings.h"
+
 /**
  * @file system_settings.h
  * @brief Configuration settings for the main application.

--- a/tests/system_config/bootloader_settings.h
+++ b/tests/system_config/bootloader_settings.h
@@ -23,6 +23,7 @@
 #include <stdbool.h>
 #include "bootloader.h"
 #include "common/config_options.h"
+#include "common_settings.h"
 
 /*
  * @brief The reset address of the application.
@@ -58,11 +59,6 @@ const PORTS_BIT_POS SWITCH_PORT_BIT = PORTS_BIT_POS_7;
  * @brief True if the switch is active high, false if active low.
  */
 const bool SWITCH_ACTIVE_HIGH = false;
-
-/**
- * @brief The hardware model.
- */
-#define HARDWARE_MODEL MODEL_ETHERNET_SK2
 
 /**
  * @brief The LEDS to flash in bootloader mode.

--- a/tests/system_config/common_settings.h
+++ b/tests/system_config/common_settings.h
@@ -1,0 +1,39 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ *
+ * common_settings.h
+ * Copyright (C) 2015 Simon Newton
+ */
+
+#ifndef TESTS_SYSTEM_CONFIG_COMMON_SETTINGS_H_
+#define TESTS_SYSTEM_CONFIG_COMMON_SETTINGS_H_
+
+#include "config_options.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief The hardware model.
+ * @sa JaRuleModel
+ */
+#define HARDWARE_MODEL MODEL_ETHERNET_SK2
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TESTS_SYSTEM_CONFIG_COMMON_SETTINGS_H_

--- a/tests/tests/Makefile.mk
+++ b/tests/tests/Makefile.mk
@@ -122,7 +122,8 @@ tests_tests_message_handler_test_LDADD = $(GMOCK_LIBS) $(GTEST_LIBS) \
                                          tests/mocks/librdmhandlermock.la \
                                          tests/mocks/libsyslogmock.la \
                                          tests/mocks/libtransceivermock.la \
-                                         tests/mocks/libtransportmock.la
+                                         tests/mocks/libtransportmock.la \
+                                         tests/harmony/mocks/libharmonymock.la
 
 tests_tests_network_model_test_SOURCES = tests/tests/NetworkModelTest.cpp
 tests_tests_network_model_test_CXXFLAGS = $(TESTING_CXXFLAGS) $(OLA_CFLAGS)

--- a/tests/tests/MessageHandlerTest.cpp
+++ b/tests/tests/MessageHandlerTest.cpp
@@ -277,16 +277,23 @@ TEST_F(MessageHandlerTest, testSetMode) {
   MessageHandler_HandleMessage(&message);
 }
 
-TEST_F(MessageHandlerTest, testGetUID) {
-  uint8_t uid_data[UID_LENGTH] = {0x7a, 0x70, 0x01, 0x02, 0x03, 0x04};
+TEST_F(MessageHandlerTest, testGetInfo) {
+  uint8_t response[] = {
+    0x03, 0x00,
+    0x7a, 0x70, 0x01, 0x02, 0x03, 0x04,
+    0, 0, 0, 0, 0, 0
+  };
 
-  EXPECT_CALL(m_transport_mock, Send(kToken, COMMAND_GET_UID, RC_OK, _, 1))
-      .With(Args<3, 4>(PayloadIs(uid_data, arraysize(uid_data))))
+  EXPECT_CALL(m_transport_mock, Send(kToken, COMMAND_GET_HARDWARE_INFO, RC_OK,
+              _, 1))
+      .With(Args<3, 4>(PayloadIs(response, arraysize(response))))
       .WillOnce(Return(true));
   EXPECT_CALL(m_rdm_handler_mock, GetUID(_))
-      .WillOnce(SetArrayArgument<0>(uid_data, uid_data + UID_LENGTH));
+      .WillOnce(SetArrayArgument<0>(
+            response + sizeof(uint16_t),
+            response + sizeof(uint16_t) + UID_LENGTH));
 
-  Message message = { kToken, COMMAND_GET_UID, 0, NULL};
+  Message message = { kToken, COMMAND_GET_HARDWARE_INFO, 0, NULL};
   MessageHandler_HandleMessage(&message);
 }
 


### PR DESCRIPTION
We've realized microchip has 3 OIDs. This handles the 2 OIDs we've seen in
production - we don't want to allocate the third unless we start shipping chips
with that OID.

The change also changes the GET_UID command to return the Ja Rule Model & the
MAC address. We'll use this in the production tool.