### PR TITLE
RDM Responder changes.

### DIFF
--- a/firmware/src/app.c
+++ b/firmware/src/app.c
@@ -156,9 +156,9 @@ void APP_Tasks(void) {
   USBTransport_Tasks();
   Transceiver_Tasks();
   USBConsole_Tasks();
-  RDMResponder_Tasks();
 
   if (Transceiver_GetMode() == T_MODE_RESPONDER) {
+    RDMResponder_Tasks();
     RDMHandler_Tasks();
     SPIRGB_Tasks();
     Temperature_Tasks();

--- a/firmware/src/dimmer_model.c
+++ b/firmware/src/dimmer_model.c
@@ -1060,7 +1060,7 @@ void DimmerModel_Initialize() {
 
     RDMResponder_SwitchResponder(&subdevice->responder);
     memcpy(g_responder->uid, parent_uid, UID_LENGTH);
-    RDMResponder_ResetToFactoryDefaults();
+    RDMResponder_InitResponder();
     g_responder->is_subdevice = true;
     g_responder->sub_device_count = NUMBER_OF_SUB_DEVICES;
   }
@@ -1081,7 +1081,7 @@ void DimmerModel_Initialize() {
 
 static void DimmerModel_Activate() {
   g_responder->def = &ROOT_RESPONDER_DEFINITION;
-  RDMResponder_ResetToFactoryDefaults();
+  RDMResponder_InitResponder();
   g_responder->sub_device_count = NUMBER_OF_SUB_DEVICES;
   g_root_device.status_message_timer = CoarseTimer_GetTime();
 }

--- a/firmware/src/led_model.c
+++ b/firmware/src/led_model.c
@@ -155,8 +155,7 @@ void LEDModel_Initialize() {}
 
 static void LEDModel_Activate() {
   g_responder->def = &RESPONDER_DEFINITION;
-  RDMResponder_ResetToFactoryDefaults();
-
+  RDMResponder_InitResponder();
   g_model.pixel_type = PIXEL_TYPE_LPD8806;
   g_model.pixel_count = DEFAULT_PIXEL_COUNT;
 }

--- a/firmware/src/moving_light.c
+++ b/firmware/src/moving_light.c
@@ -457,7 +457,7 @@ void MovingLightModel_Initialize() {
 
 static void MovingLightModel_Activate() {
   g_responder->def = &RESPONDER_DEFINITION;
-  RDMResponder_ResetToFactoryDefaults();
+  RDMResponder_InitResponder();
   g_moving_light.clock_timer = CoarseTimer_GetTime();
 }
 

--- a/firmware/src/network_model.c
+++ b/firmware/src/network_model.c
@@ -601,7 +601,7 @@ void NetworkModel_Initialize() {
 
 static void NetworkModel_Activate() {
   g_responder->def = &RESPONDER_DEFINITION;
-  RDMResponder_ResetToFactoryDefaults();
+  RDMResponder_InitResponder();
 }
 
 static void NetworkModel_Deactivate() {}

--- a/firmware/src/proxy_model.c
+++ b/firmware/src/proxy_model.c
@@ -262,7 +262,7 @@ void ProxyModel_Initialize() {
     memcpy(g_responder->uid, parent_uid, UID_LENGTH);
     g_responder->uid[UID_LENGTH - 1] += (i + 1u);
     g_responder->def = &CHILD_DEVICE_RESPONDER_DEFINITION;
-    RDMResponder_ResetToFactoryDefaults();
+    RDMResponder_InitResponder();
     g_responder->is_proxied_device = true;
   }
 
@@ -271,7 +271,7 @@ void ProxyModel_Initialize() {
 
 static void ProxyModel_Activate() {
   g_responder->def = &ROOT_RESPONDER_DEFINITION;
-  RDMResponder_ResetToFactoryDefaults();
+  RDMResponder_InitResponder();
   g_responder->is_managed_proxy = true;
   ResetProxyBuffers();
 }

--- a/firmware/src/rdm_responder.c
+++ b/firmware/src/rdm_responder.c
@@ -170,10 +170,7 @@ void RDMResponder_Initialize(const RDMResponderSettings *settings) {
 
   memcpy(g_responder->uid, settings->uid, UID_LENGTH);
   g_responder->def = NULL;
-  g_responder->is_subdevice = false;
-  g_responder->is_managed_proxy = false;
-  g_responder->is_proxied_device = false;
-  RDMResponder_ResetToFactoryDefaults();
+  RDMResponder_InitResponder();
 }
 
 void RDMResponder_Tasks() {
@@ -202,14 +199,25 @@ void RDMResponder_RestoreResponder() {
   g_responder = &root_responder;
 }
 
+void RDMResponder_InitResponder() {
+  // This resets the non-mutable state of the responder and then calls
+  // RDMResponder_ResetToFactoryDefaults() to reset the mutable state.
+  g_responder->sensors = NULL;
+  g_responder->is_subdevice = false;
+  g_responder->is_managed_proxy = false;
+  g_responder->is_proxied_device = false;
+
+  RDMResponder_ResetToFactoryDefaults();
+}
+
 void RDMResponder_ResetToFactoryDefaults() {
-  g_responder->queued_message_count = 0u;
   g_responder->dmx_start_address = INVALID_DMX_START_ADDRESS;
   g_responder->sub_device_count = 0u;
   g_responder->current_personality = 1u;
+  g_responder->queued_message_count = 0u;
+
   g_responder->is_muted = false;
   g_responder->identify_on = false;
-  g_responder->sensors = NULL;
 
   if (g_responder->def) {
     RDMUtil_StringCopy(g_responder->device_label, RDM_DEFAULT_STRING_SIZE,
@@ -220,7 +228,6 @@ void RDMResponder_ResetToFactoryDefaults() {
       g_responder->dmx_start_address = 1u;
     }
   }
-
   g_responder->using_factory_defaults = true;
 }
 

--- a/firmware/src/rdm_responder.h
+++ b/firmware/src/rdm_responder.h
@@ -359,6 +359,11 @@ void RDMResponder_SwitchResponder(RDMResponder *responder);
 void RDMResponder_RestoreResponder();
 
 /**
+ * @brief Initialize the current responder with default values.
+ */
+void RDMResponder_InitResponder();
+
+/**
  * @brief Reset an RDMResponder to the factory defaults.
  */
 void RDMResponder_ResetToFactoryDefaults();

--- a/firmware/src/sensor_model.c
+++ b/firmware/src/sensor_model.c
@@ -101,7 +101,7 @@ static void SensorModel_Activate() {
     }
   }
 
-  RDMResponder_ResetToFactoryDefaults();
+  RDMResponder_InitResponder();
   SampleSensors();
   g_responder->sensors = g_sensor_model.sensors;
 }


### PR DESCRIPTION
- Only flash the Identify & Mute leds when we're in responder mode
- Correctly reset the control field flags when we switch models.

Closes #227 