### PR TITLE
Clang 3.8 is now working again, so just use that for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,7 @@ matrix:
   fast_finish: true
   include:
     - compiler: clang
-      env:
-        - TASK='compile'
-        - CLANG_VERSION='3.8'
-    - compiler: clang
-      env:
-        - TASK='compile'
-        - CLANG_VERSION='3.7'
+      env: TASK='compile'
     - compiler: gcc
       env: TASK='compile'
     - compiler: gcc
@@ -25,10 +19,6 @@ matrix:
     - env: TASK='lint'
     - env: TASK='check-licences'
   allow_failures:
-    - compiler: clang
-      env:
-        - TASK='compile'
-        - CLANG_VERSION='3.8'
     - compiler: gcc
       env: TASK='coverage'
     - compiler: gcc
@@ -75,13 +65,10 @@ before_install:
  - if [ "$CXX" = "g++-4.9" -o "$CXX" = "g++-5" ]; then sudo rm /usr/bin/g++; sudo rm /usr/bin/gcc; fi
  #Install latest clang if we're compiling with clang
  #clang-3.8 packages seem to be unsigned so need forcing
- - if [ "$CXX" = "clang++" -a "$CLANG_VERSION" = "3.8" ]; then sudo apt-get install --force-yes clang-3.8; fi
- - if [ "$CXX" = "clang++" -a "$CLANG_VERSION" = "3.8" ]; then export CXX="clang++-3.8" CC="clang-3.8"; fi
- #Install latest working clang if we're compiling with clang
- - if [ "$CXX" = "clang++" -a "$CLANG_VERSION" = "3.7" ]; then sudo apt-get install -qq clang-3.7; fi
- - if [ "$CXX" = "clang++" -a "$CLANG_VERSION" = "3.7" ]; then export CXX="clang++-3.7" CC="clang-3.7"; fi
+ - if [ "$CXX" = "clang++" ]; then sudo apt-get install --force-yes -qq clang-3.8; fi
+ - if [ "$CXX" = "clang++" ]; then export CXX="clang++-3.8" CC="clang-3.8"; fi
  #Remove the old clang to ensure we're using the latest ones
- - if [ "$CXX" = "clang++-3.7" -o "$CXX" = "clang++-3.8" ]; then sudo rm /usr/local/clang-3.4/bin/clang; sudo rm /usr/local/clang-3.4/bin/clang++; fi
+ - if [ "$CXX" = "clang++-3.8" ]; then sudo rm /usr/local/clang-3.4/bin/clang; sudo rm /usr/local/clang-3.4/bin/clang++; fi
  #Report the compiler version
  - $CXX --version
  #Install coveralls if required


### PR DESCRIPTION
Revert "Install two versions of clang until we get 3.8 working again"

This reverts commit 15ff4a1f31d5cb3936a6725408eea19cbd8a117e.

Conflicts:

	.travis.yml